### PR TITLE
Potential fix for code scanning alert no. 68: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -18,6 +18,10 @@
 
 name: "Microsoft Defender For Devops"
 
+permissions:
+  contents: read
+  security-events: write
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Vs-Code/security/code-scanning/68](https://github.com/Git-Hub-Chris/Vs-Code/security/code-scanning/68)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will explicitly define the minimal permissions required for the workflow to function. Based on the workflow's steps, it appears that the workflow only needs to read repository contents and upload SARIF files to the Security tab. Therefore, we will set `contents: read` and `security-events: write` permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
