### PR TITLE
Potential fix for code scanning alert no. 76: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/neuralegion.yml
+++ b/.github/workflows/neuralegion.yml
@@ -149,6 +149,9 @@
 
 name: "NeuraLegion"
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Vs-Code/security/code-scanning/76](https://github.com/Git-Hub-Chris/Vs-Code/security/code-scanning/76)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow appears to perform a scan using the NeuraLegion action and does not modify repository contents, the minimal required permission is likely `contents: read`. This will restrict the `GITHUB_TOKEN` to only have read access to the repository contents, ensuring that no write operations can be performed.

The `permissions` block will be added at the root level of the workflow, so it applies to all jobs in the workflow. This ensures consistency and avoids the need to define permissions for each job individually.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
